### PR TITLE
Add provider based notes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ The supported providers are:
 
 Supporting more providers are working in progress. Free free to [file an issue](https://github.com/aircodelabs/grasp/issues) to request a new provider.
 
+**Notes for other providers:**
+
+*OPENAI*:
+
+
+- make sure your account supports [computer-use-preview](https://platform.openai.com/docs/guides/tools-computer-use)
+
 ## Stay in the Loop
 
 Grasp is moving fast — we're shipping new features, expanding integrations, and refining the agent experience every week.


### PR DESCRIPTION
Add a note that OpenAI account must support computer-use-preview functionality. Not all accounts support it as of 05.16.2025